### PR TITLE
Actually check for proxied state

### DIFF
--- a/cloudflareddns/cloudflareddns.py
+++ b/cloudflareddns/cloudflareddns.py
@@ -152,7 +152,8 @@ def update(hostname, ip, ttl=None):
 
         # Yes, we need to update this record - we know it's the same address type
         dnsRecordId = dnsRecord['id']
-
+        desiredRecordData['proxied'] = dnsRecord['proxied']
+        
         try:
             cf.zones.dns_records.put(zone_id, dnsRecordId, data=desiredRecordData)
         except CloudFlare.exceptions.CloudFlareAPIError as e:


### PR DESCRIPTION
The script does not actually put the current proxied state into the data that are to be sent to the API. Because of this, proxied state will be always set to false. This oneliner will store the current state of the proxied data and send it back.